### PR TITLE
[Fix] Frozen string literals error on Ruby 2.7

### DIFF
--- a/lib/protokoll/formater.rb
+++ b/lib/protokoll/formater.rb
@@ -61,12 +61,12 @@ module Protokoll
     end
 
     def expand_times(pattern)
-      pattern.sub!("%y", Time.now.strftime("%y"))
-      pattern.sub!("%Y", Time.now.strftime("%Y"))
-      pattern.sub!("%d", Time.now.strftime("%d"))
-      pattern.sub!("%m", Time.now.strftime("%m"))
-      pattern.sub!("%M", Time.now.strftime("%M"))
-      pattern.sub("%H",  Time.now.strftime("%H"))
+      pattern.sub("%y", Time.now.strftime("%y"))
+        .sub("%Y", Time.now.strftime("%Y"))
+        .sub("%d", Time.now.strftime("%d"))
+        .sub("%m", Time.now.strftime("%m"))
+        .sub("%M", Time.now.strftime("%M"))
+        .sub("%H",  Time.now.strftime("%H"))
     end
 
     def digits_size(pattern)


### PR DESCRIPTION
## Reff

[Core methods returning frozen strings](https://rubyreferences.github.io/rubychanges/2.7.html#core-methods-returning-frozen-strings)